### PR TITLE
Update from Linux upstream kernel source 5.10.226

### DIFF
--- a/SOURCES/1000-showversion.patch
+++ b/SOURCES/1000-showversion.patch
@@ -124,7 +124,7 @@ index 8b1d77e..010a7c3 100644
  #include "igc_tsn.h"
  
  #define DRV_SUMMARY	"Intel(R) 2.5G Ethernet Linux Driver"
-+#define DRV_VERSION	"5.10.214-1"
++#define DRV_VERSION	"5.10.226-1"
  
  #define DEFAULT_MSG_ENABLE (NETIF_MSG_DRV | NETIF_MSG_PROBE | NETIF_MSG_LINK)
  

--- a/SOURCES/intel-igc.tar.gz
+++ b/SOURCES/intel-igc.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7c803d2c3634321d75edffe5b71fb23826f945cab227332b558ae075acc910e2
-size 98761
+oid sha256:14c181b1b67cdbe1bef5086564c38a23b34d232bd736ccdcfdf49cd241df9601
+size 98044

--- a/SPECS/intel-igc.spec
+++ b/SPECS/intel-igc.spec
@@ -1,8 +1,3 @@
-%global package_speccommit 525b160e0537cadf8032b68622d1f6962d518feb
-%global usver 5.10.214
-%global xsver 3
-%global xsrel %{xsver}%{?xscount}%{?xshash}
-%global package_srccommit 5.10.214
 %define vendor_name Intel
 %define vendor_label intel
 %define driver_name igc
@@ -20,8 +15,8 @@
 
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}
-Version: 5.10.214
-Release: %{?xsrel}.1%{?dist}
+Version: 5.10.226
+Release: 1%{?dist}
 License: GPL
 Source0: intel-igc.tar.gz
 Patch0: 0001-Change-makefile-for-building-igc.patch
@@ -81,6 +76,9 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 %{?_cov_results_package}
 
 %changelog
+* Fri Dec 20 2024 Andrew Lindh <andrew@netplex.net> - 5.10.226-1
+- Update with kernel source 5.10.226 to fix minor lock bug
+
 * Thu Jun 20 2024 Thierry Escande <thierry.escande@vates.tech> - 5.10.214-3.1
 - Obsoletes igc-module RPM
 - Import XCP-ng specific patches from obsolete igc-module RPM


### PR DESCRIPTION
Minor lock fix on error return (upstream kernel code update)

This PR replaces the original [PR](https://github.com/xcp-ng-rpms/intel-igc/pull/2) by squashing its 2 commits.