### PR TITLE
fix missing Provides for obsoleted package

### DIFF
--- a/SPECS/intel-igc.spec
+++ b/SPECS/intel-igc.spec
@@ -21,7 +21,7 @@
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}
 Version: 5.10.214
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 License: GPL
 Source0: intel-igc.tar.gz
 Patch0: 0001-Change-makefile-for-building-igc.patch
@@ -82,6 +82,9 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 %{?_cov_results_package}
 
 %changelog
+* Tue Feb 25 2025 Gaëtan Lehmann <gaetan.lehmann@vates.tech> - 5.10.214-3.3
+- fix missing provides for the old package name
+
 * Thu Jun 20 2024 Thierry Escande <thierry.escande@vates.tech> - 5.10.214-3.1
 - Obsoletes igc-module RPM
 - Import XCP-ng specific patches from obsolete igc-module RPM

--- a/SPECS/intel-igc.spec
+++ b/SPECS/intel-igc.spec
@@ -21,7 +21,7 @@
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}
 Version: 5.10.214
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 License: GPL
 Source0: intel-igc.tar.gz
 Patch0: 0001-Change-makefile-for-building-igc.patch
@@ -44,6 +44,7 @@ Requires(postun): /usr/sbin/depmod
 
 # This RPM obsoletes XCP-ng specific RPM igc-module
 Obsoletes: igc-module < 5.10.200-2
+Provides: igc-module = %{version}-%{release}
 
 %description
 %{vendor_name} %{driver_name} device drivers for the Linux Kernel


### PR DESCRIPTION
having both `Obsoletes` and `Provides` is what is recommended in the [Fedora Packaging Guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/#renaming-or-replacing-existing-packages) and is required for yum to be able to install a package that requires the old package name.