### PR TITLE
Kernel vers 5.10.237: Minor PTP fixes. Use dynamic version info.

### DIFF
--- a/SOURCES/1000-showversion.patch
+++ b/SOURCES/1000-showversion.patch
@@ -1,6 +1,16 @@
 
 ### Add ethtool show version support from later driver source
+### Add MODULE_VERSION
 ### Also show XCP driver version
+
+##########
+## NOTE ##
+##########
+## This depends on RPM build adding DRV_VERSION to igc.h
+##
+## Must be included in spec file:
+##   /usr/bin/echo '#define DRV_VERSION "%{version}"' >> igc.h
+##
 
 diff --git a/igc_defines.h b/igc_defines.h
 index 352b50d..fe6ff3b 100644
@@ -124,7 +134,7 @@ index 8b1d77e..010a7c3 100644
  #include "igc_tsn.h"
  
  #define DRV_SUMMARY	"Intel(R) 2.5G Ethernet Linux Driver"
-+#define DRV_VERSION	"5.10.226-1"
++/* DRV_VERSION is added to igc.h by RPM build from spec file */
  
  #define DEFAULT_MSG_ENABLE (NETIF_MSG_DRV | NETIF_MSG_PROBE | NETIF_MSG_LINK)
  
@@ -137,3 +147,13 @@ index 8b1d77e..010a7c3 100644
  	"Copyright(c) 2018 Intel Corporation.";
  
 
+--- a/igc_main.c	2025-05-19 20:35:13.381367239 +0000
++++ b/igc_main.c	2025-05-19 20:35:38.141580448 +0000
+@@ -29,6 +29,7 @@
+ MODULE_LICENSE("GPL v2");
+ module_param(debug, int, 0);
+ MODULE_PARM_DESC(debug, "Debug level (0=none,...,16=all)");
++MODULE_VERSION(DRV_VERSION);
+ 
+ char igc_driver_name[] = "igc";
+ static const char igc_driver_string[] = DRV_SUMMARY;

--- a/SOURCES/intel-igc.tar.gz
+++ b/SOURCES/intel-igc.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:14c181b1b67cdbe1bef5086564c38a23b34d232bd736ccdcfdf49cd241df9601
-size 98044
+oid sha256:35ce475692073972328ca9c83b639352f449971dbcb20a97cf0ab0756cfe44f4
+size 97479

--- a/SPECS/intel-igc.spec
+++ b/SPECS/intel-igc.spec
@@ -15,8 +15,8 @@
 
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}
-Version: 5.10.226
-Release: 2%{?dist}
+Version: 5.10.237
+Release: 1%{?dist}
 License: GPL
 Source0: intel-igc.tar.gz
 Patch0: 0001-Change-makefile-for-building-igc.patch
@@ -49,6 +49,9 @@ version %{kernel_version}.
 %autosetup -p1 -n %{name}-%{version}
 %{?_cov_prepare}
 
+# Set module version to upstream kernel release
+/usr/bin/echo '#define DRV_VERSION "%{version}"' >> igc.h
+
 %build
 %{?_cov_wrap} %{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd) KSRC=/lib/modules/%{kernel_version}/build modules
 
@@ -77,6 +80,11 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 %{?_cov_results_package}
 
 %changelog
+* Mon May 19 2025 Andrew Lindh <andrew@netplex.net> - 5.10.237-1
+- Minor PTP fixes from upstream
+- Make show version number dynamic based on RPM build spec file
+- Add MODULE_VERSION
+
 * Tue Feb 25 2025 Gaëtan Lehmann <gaetan.lehmann@vates.tech> - 5.10.226-2
 - fix missing provides for the old package name
 


### PR DESCRIPTION
Update to kernel version 5.10.237
- Minor PTP fixes from upstream

Also:
- Make show version number dynamic based on RPM build spec file
- Add MODULE_VERSION
